### PR TITLE
streamlined fao featured orgs/groups api #14

### DIFF
--- a/ckanext/faociok/helpers.py
+++ b/ckanext/faociok/helpers.py
@@ -3,7 +3,7 @@
 
 import json
 from ckan.lib.i18n import get_lang
-import ckan.logic as logic
+from ckan.plugins import toolkit as t
 from ckanext.faociok.models import Vocabulary, VocabularyTerm
 
 
@@ -36,8 +36,20 @@ def load_json(value, fail=False):
 def get_vocabulary_items_annotated(vocabulary_name):
     return VocabularyTerm.get_terms(vocabulary_name, lang=get_lang(), include_dataset_count=True)
 
-def fao_get_action(action_name, data_dict=None):
-    '''BAD BAD WORKAROUND'''
-    if data_dict is None:
-        data_dict = {}
-    return logic.get_action(action_name)({}, data_dict)
+def get_groups_featured():
+    return _get_featured('group')
+
+def get_organizations_featured():
+    return _get_featured('organization')
+
+def _get_featured(group_type, max_results=4):
+    params_with_pkg = {'limit': 4,
+                        'all_fields': True,
+                        'sort': 'package_count'}
+    params_any = {'limit': 4, 'all_fields': True}
+    call_name = '{}_list'.format(group_type)
+    action = t.get_action(call_name)
+    
+    data = action({}, params_with_pkg)\
+            or action({}, params_any)
+    return data[:max_results]

--- a/ckanext/faociok/plugin.py
+++ b/ckanext/faociok/plugin.py
@@ -88,7 +88,8 @@ class FaociokPlugin(plugins.SingletonPlugin, t.DefaultDatasetForm):
             'get_fao_datatype': h.get_fao_datatype,
             'get_fao_m49_region': h.get_fao_m49_region,
             'load_json': h.load_json,
-            'fao_get_action': h.fao_get_action,
+            'get_fao_groups_featured': h.get_groups_featured,
+            'get_fao_organizations_featured': h.get_organizations_featured,
         }
 
     # IFacets

--- a/ckanext/faociok/templates/home/layout1.html
+++ b/ckanext/faociok/templates/home/layout1.html
@@ -13,6 +13,7 @@
         {% snippet 'home/snippets/categories.html' %}
       </div>
       <div class="span6 col2">
+
         {% snippet 'home/snippets/organizations.html' %}
       </div>
 

--- a/ckanext/faociok/templates/home/snippets/categories.html
+++ b/ckanext/faociok/templates/home/snippets/categories.html
@@ -1,6 +1,6 @@
 {# get groups. package_count will return groups with packages only, so we'll fall back to all groups if no package count is available #}
-{% set groups = h.fao_get_action('group_list', {'limit': 4, 'all_fields': True, 'sort': 'package_count'}) or h.fao_get_action('group_list', {'limit': 4, 'all_fields': True}) %}
 
+{% set groups = h.get_fao_groups_featured() %}
 <div class="module box container-fluid module-narrow module-shallow">
     <div class="module-content">
     <h3 class="heading">{{ _('Groups') }}</h3>

--- a/ckanext/faociok/templates/home/snippets/organizations.html
+++ b/ckanext/faociok/templates/home/snippets/organizations.html
@@ -1,11 +1,11 @@
 {# get groups. package_count will return groups with packages only, so we'll fall back to all groups if no package count is available #}
-{% set groups = h.fao_get_action('organization_list', {'limit': 4, 'all_fields': True, 'sort': 'package_count'}) or h.fao_get_action('organization_list', {'limit': 4, 'all_fields': True}) %}
 
+{% set organizations = h.get_fao_organizations_featured() %}
 <div class="module box container-fluid module-narrow module-shallow">
     <div class="module-content">
     <h3 class="heading">{{ _('Organizations') }}</h3>
     <div class="row">
-      {% for group in groups %}
+      {% for group in organizations %}
         {% if loop.index0 > 0 %}
             {% if loop.index0%2==0 %}<div class="clearfix visible-lg"></div>{% endif %}
             {% if loop.index0%1==0 %}<div class="clearfix visible-md clearfix-ie7"></div>{% endif %}


### PR DESCRIPTION
fix #14 

This is reworked fix from @etj. As agreed with @tdipisa, due to limitations in ckan (no `ckan.plugins.toolkit` available in snippets/templates, `helpers.call_action()` removed in ckan 2.6+), I've added specialized helpers, so no need to pass any args in snippet. 