### PR TITLE
validators handle default values #28

### DIFF
--- a/ckanext/faociok/plugin.py
+++ b/ckanext/faociok/plugin.py
@@ -26,6 +26,7 @@ class FaociokPlugin(plugins.SingletonPlugin, t.DefaultDatasetForm):
         t.add_template_directory(config_, 'templates')
         t.add_public_directory(config_, 'public')
         t.add_resource('fanstatic', 'faociok')
+        return config_
 
     # IDatasetForm
 
@@ -42,29 +43,30 @@ class FaociokPlugin(plugins.SingletonPlugin, t.DefaultDatasetForm):
     def create_package_schema(self):
         schema = super(FaociokPlugin, self).create_package_schema()
         schema.update(s.get_create_package_schema())
-
-        for k in schema.keys():
-            if k.startswith('fao_'):
-                schema[k] += [t.get_converter('convert_to_extras')]
+        self._update_schema(schema, 'convert_to_extras', before=False)
         return schema
 
     def update_package_schema(self):
         schema = super(FaociokPlugin, self).update_package_schema()
         schema.update(s.get_update_package_schema())
-        
-        for k in schema.keys():
-            if k.startswith('fao_'):
-                schema[k] += [t.get_converter('convert_to_extras')]
-
+        self._update_schema(schema, 'convert_to_extras', before=False)
         return schema
 
     def show_package_schema(self):
         schema = super(FaociokPlugin, self).show_package_schema()
         schema.update(s.get_show_package_schema())
+        self._update_schema(schema, 'convert_from_extras', before=True)
+        return schema
+
+    def _update_schema(self, schema, converter, before=False):
         for k in schema.keys():
             if k.startswith('fao_'):
                 field = schema[k]
-                schema[k] = [t.get_converter('convert_from_extras')] + field
+                if before:
+                    schema[k] = [t.get_converter(converter)] + field
+                else:
+                    schema[k] = field + [t.get_converter(converter)]
+
         return schema
 
     # IValidators

--- a/ckanext/faociok/schema.py
+++ b/ckanext/faociok/schema.py
@@ -23,7 +23,7 @@ def _get_package_schema():
          'is_required': True,
          },
          {'name': 'fao_m49_regions',
-          'validators': [t.get_validator('ignore_missing'), t.get_validator('fao_m49_regions')],
+          'validators': [t.get_validator('fao_m49_regions')],
           'element': 'select',
           'multiple': True,
           'autocomplete': True,

--- a/ckanext/faociok/validators.py
+++ b/ckanext/faociok/validators.py
@@ -2,11 +2,18 @@
 # -*- coding: utf-8 -*-
 
 import json
-from ckan.common import _, ungettext
+from ckan.common import _, ungettext, config
 from ckan.plugins.toolkit import Invalid
 from ckanext.faociok.models import Vocabulary
+from ckan.lib.navl.dictization_functions import Missing
+
+CONFIG_FAO_DATATYPE = 'ckanext.faociok.datatype'
+
+DEFAULT_DATATYPE = config.get(CONFIG_FAO_DATATYPE)
 
 def fao_datatype(value, context):
+    if not value and DEFAULT_DATATYPE:
+        return DEFAULT_DATATYPE
     try:
         v = Vocabulary.get(Vocabulary.VOCABULARY_DATATYPE)
         if not v.valid_term(value):
@@ -16,22 +23,30 @@ def fao_datatype(value, context):
     
     return value
 
-def fao_m49_regions(value, context):
-    if not value:
-        return
-    value = _deserialize_from_array(value)
-    validated = []
-    try:
-        v = Vocabulary.get(Vocabulary.VOCABULARY_M49_REGIONS)
-        for term in value:
-            if not v.valid_term(term):
-                raise ValueError(_("Term not valid: {}").format(term))
-            validated.append(term)
-    except Exception, err:
-        raise Invalid(_("Invalid m49 regions: {} {}").format(value, err))
-    return validated
+def fao_m49_regions(key, flattened_data, errors, context):
+    # we use extended api to update data dict in-place
+    # this way we avoid various errors in harvesters,
+    # which don't populate extras properly
+    value = flattened_data[key]
+    if isinstance(value, Missing) or value is None:
+        flattened_data[key] = []
+    else:
+        value = _deserialize_from_array(value)
+        validated = []
+        try:
+            v = Vocabulary.get(Vocabulary.VOCABULARY_M49_REGIONS)
+            for term in value:
+                if not v.valid_term(term):
+                    errors.append(ValueError(_("Term not valid: {}").format(term)))
+                    break
+                validated.append(term)
+            flattened_data[key] = validated
+        except Exception, err:
+            errors.append(Invalid(_("Invalid m49 regions: {} {}").format(value, err)))
 
 def _serialize_to_array(value):
+    if isinstance(value, (str, unicode,)) and value.startswith('{') and value.endswith('}'):
+        return value
     if not isinstance(value, (list, tuple, set,)):
         value = [value]
     serialized = ','.join('{}'.format(v) for v in value)
@@ -39,8 +54,12 @@ def _serialize_to_array(value):
 
 def _deserialize_from_array(value):
 
-    if not value:
-        return 
+    # we distinct between None and empty list
+    if value is None:
+        return []
+    # shorthand for empty array
+    elif value == '{}':
+        return []
     if not isinstance(value, list):
         try:
             value = json.loads(value)
@@ -51,7 +70,10 @@ def _deserialize_from_array(value):
     # handle {,} notation
     elif isinstance(value, (str, unicode,)):
         if value.startswith('{') and value.endswith('}'):
-            value = value[1:-1].split(',')
+            if not value[1:-1]:
+                value = []
+            else:
+                value = value[1:-1].split(',')
         elif isinstance(value, (str, unicode,)) and value.isdigit():
             value = [value]
         else:

--- a/ckanext/faociok/validators.py
+++ b/ckanext/faociok/validators.py
@@ -53,9 +53,7 @@ def _serialize_to_array(value):
     return '{{{}}}'.format(serialized)
 
 def _deserialize_from_array(value):
-
-    # we distinct between None and empty list
-    if value is None:
+    if not value:
         return []
     # shorthand for empty array
     elif value == '{}':


### PR DESCRIPTION
fix https://github.com/geosolutions-it/C013-FAO-CIOK-CKAN/issues/28

This updates validators to populate default values for fao fields. Harvesters may omit to create some fields in extras, which will cause validation/db saving errors. see https://github.com/geosolutions-it/C013-FAO-CIOK-CKAN/issues/28#issuecomment-420401516

To make this fully work, following line should be added to config:

`ckanext.faociok.datatype=other`